### PR TITLE
move currentValue from bindings to el

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
 const css = 'display:block;display:-webkit-box;-webkit-box-orient:vertical;overflow:hidden;text-overflow:ellipsis'
-const currentValueProp = "data-v-line-clamp-current-value"
+const currentValueProp = "vLineClampValue"
 
 const truncateText = function (el, bindings, needsFallback) {
   let lines = parseInt(bindings.value)

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 const css = 'display:block;display:-webkit-box;-webkit-box-orient:vertical;overflow:hidden;text-overflow:ellipsis'
+const currentValueProp = "data-v-line-clamp-current-value"
 
 const truncateText = function (el, bindings, needsFallback) {
   let lines = parseInt(bindings.value)
@@ -6,8 +7,8 @@ const truncateText = function (el, bindings, needsFallback) {
     console.error('Parameter for vue-line-clamp must be a number')
     return
   }
-  else if (lines !== bindings.def.currentValue) {
-    bindings.def.currentValue = lines
+  else if (lines !== el[currentValueProp]) {
+    el[currentValueProp] = lines
 
     if (needsFallback) {
       if (lines) {
@@ -72,3 +73,4 @@ const VueLineClamp = {
 }
 
 export default VueLineClamp
+


### PR DESCRIPTION
fixes #2 
before this fix, currentValue was global which caused only the first element to be clamped.  This change saves the value to an [html5 data attribute](http://w3c.github.io/html/single-page.html#embedding-custom-non-visible-data-with-the-data-attributes) instead so that we can have a different currentValue per element.