### PR TITLE
add babel settings to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,10 @@
   "bugs": {
     "url": "https://github.com/Frondor/vue-line-clamp/issues"
   },
-  "homepage": "https://github.com/Frondor/vue-line-clamp#readme"
+  "homepage": "https://github.com/Frondor/vue-line-clamp#readme",
+  "babel": {
+    "presets": [
+      "es2015"
+    ]
+  }
 }


### PR DESCRIPTION
Even though you aren't using babel directly anymore, you still need to include a babel preset in package.json or .babelrc  in your npm package.  If you don't, clients' build systems wont know how to transform it to ES5.  Specifically, I ran into this problem https://github.com/webpack/webpack/issues/2972 due to the use of the let keyword.