### PR TITLE
Improve CSS readability and fix long word breaks

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -22,6 +22,10 @@
     <p v-line-clamp:26="lines" style="width: 200px">
       Truncate my lorem ipsum dolor, sit amet consectetur adipisicing elit. Dolore, neque minima libero voluptatibus voluptate enim earum qui tempora sed sequi fugiat aut commodi laboriosam iste cupiditate quo veritatis quam obcaecati.
     </p>
+
+    <p v-line-clamp:26="lines" style="width: 200px">
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    </p>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/vue@2.5.13/dist/vue.js"></script>
   <script src="dist/vue-line-clamp.umd.js"></script>

--- a/dist/vue-line-clamp.cjs.js
+++ b/dist/vue-line-clamp.cjs.js
@@ -44,9 +44,15 @@ const VueLineClamp = {
       { importCss: false, textOverflow: "ellipsis" },
       options
     );
-    const styles =
-      "display:block;display:-webkit-box;-webkit-box-orient:vertical;overflow:hidden;text-overflow:" +
-      options.textOverflow;
+
+    const styles = `
+      display: block;
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      word-break: break-word;
+      text-overflow: ${options.textOverflow};
+    `;
 
     if (options.importCss) {
       const stylesheets = window.document.styleSheets,

--- a/dist/vue-line-clamp.esm.js
+++ b/dist/vue-line-clamp.esm.js
@@ -42,9 +42,15 @@ const VueLineClamp = {
       { importCss: false, textOverflow: "ellipsis" },
       options
     );
-    const styles =
-      "display:block;display:-webkit-box;-webkit-box-orient:vertical;overflow:hidden;text-overflow:" +
-      options.textOverflow;
+
+    const styles = `
+      display: block;
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      word-break: break-word;
+      text-overflow: ${options.textOverflow};
+    `;
 
     if (options.importCss) {
       const stylesheets = window.document.styleSheets,

--- a/dist/vue-line-clamp.umd.js
+++ b/dist/vue-line-clamp.umd.js
@@ -43,7 +43,8 @@ var truncateText = function truncateText(el, bindings, useFallbackFunc) {
 var VueLineClamp = {
   install: function install(Vue, options) {
     options = Object.assign({ importCss: false, textOverflow: "ellipsis" }, options);
-    var styles = "display:block;display:-webkit-box;-webkit-box-orient:vertical;overflow:hidden;text-overflow:" + options.textOverflow;
+
+    var styles = "\n      display: block;\n      display: -webkit-box;\n      -webkit-box-orient: vertical;\n      overflow: hidden;\n      word-break: break-word;\n      text-overflow: " + options.textOverflow + ";\n    ";
 
     if (options.importCss) {
       var stylesheets = window.document.styleSheets,

--- a/src/main.js
+++ b/src/main.js
@@ -42,9 +42,15 @@ const VueLineClamp = {
       { importCss: false, textOverflow: "ellipsis" },
       options
     );
-    const styles =
-      "display:block;display:-webkit-box;-webkit-box-orient:vertical;overflow:hidden;text-overflow:" +
-      options.textOverflow;
+
+    const styles = `
+      display: block;
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      word-break: break-word;
+      text-overflow: ${options.textOverflow};
+    `;
 
     if (options.importCss) {
       const stylesheets = window.document.styleSheets,


### PR DESCRIPTION
- Improve CSS readability;
- Create long word example;
- Fix #20 with `word-break` CSS property.